### PR TITLE
Feature/start end blog post fetching

### DIFF
--- a/Gibe.Umbraco.Blog.Tests/BlogServiceTests.cs
+++ b/Gibe.Umbraco.Blog.Tests/BlogServiceTests.cs
@@ -24,11 +24,31 @@ namespace Gibe.Umbraco.Blog.Tests
 			return pagerService.Object;
 		}
 
+		private IBlogPostMapper<BlogModel> BlogPostMapper(int searchResultsCount)
+		{
+			var blogPostMapper = new Mock<IBlogPostMapper<BlogModel>>();
+			blogPostMapper.Setup(m => m.ToBlogPosts(It.IsAny<IEnumerable<SearchResult>>()))
+				.Returns(MappedSearchResults(searchResultsCount));
+
+			return blogPostMapper.Object;
+		}
+
+		private IEnumerable<BlogModel> MappedSearchResults(int searchResultsCount)
+		{
+			var mappedSearchResults = new List<BlogModel>();
+			for(var i=0 ; i<searchResultsCount ; i++)
+			{
+				mappedSearchResults.Add(new BlogModel());
+			}
+			return mappedSearchResults;
+		}
+
 		[Test]
 		public void GetRelatedPosts_Uses_Correct_Filters()
 		{
-			var blogSearch = new FakeBlogSearch(GetSearchResults());
-			var blogService = new BlogService<BlogModel>(new FakeModelConverter(GetBlogPosts()), PagerService(), blogSearch, UmbracoWrapper(Content(1), Content(2), Content(3)));
+			var searchResults = GetSearchResults();
+			var blogSearch = new FakeBlogSearch(searchResults);
+			var blogService = new BlogService<BlogModel>(PagerService(), blogSearch, BlogPostMapper(searchResults.Count()));
 			var testPost = new BlogModel
 			{
 				Tags = new List<string>

--- a/Gibe.Umbraco.Blog.Tests/Gibe.Umbraco.Blog.Tests.csproj
+++ b/Gibe.Umbraco.Blog.Tests/Gibe.Umbraco.Blog.Tests.csproj
@@ -268,6 +268,7 @@
   <ItemGroup>
     <Compile Include="BlogServiceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnpagedBlogServiceTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Gibe.Umbraco.Blog.Tests/UnpagedBlogServiceTests.cs
+++ b/Gibe.Umbraco.Blog.Tests/UnpagedBlogServiceTests.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Examine;
+using Gibe.Umbraco.Blog;
+using Gibe.Umbraco.Blog.Tests;
+using Moq;
+using NUnit.Framework;
+
+namespace Gibe.UmbracoBlog.Tests
+{
+	[TestFixture]
+	public class UnpagedBlogServiceTests
+	{
+		private MockRepository _repository;
+
+		[SetUp]
+		public void Setup()
+		{
+			_repository = new MockRepository(MockBehavior.Strict);
+		}
+
+		private IBlogPostMapper<BlogModel> BlogPostMapper(int searchResultsCount)
+		{
+			var mock = _repository.Create<IBlogPostMapper<BlogModel>>();
+
+			var mappedSearchResults = new List<BlogModel>();
+			for (var i = 0; i < searchResultsCount; i++)
+			{
+				mappedSearchResults.Add(new BlogModel{Id = i});
+			}
+
+			mock.Setup(m => m.ToBlogPosts(It.IsAny<IEnumerable<SearchResult>>())).Returns(mappedSearchResults);
+
+			return mock.Object;
+		}
+
+		private IBlogSearch BlogSearch(ISearchResults searchResults)
+		{
+			return new FakeBlogSearch(searchResults);
+		}
+
+		private ISearchResults SearchResults(int searchResultsCount)
+		{
+			var searchResults = new List<SearchResult>();
+			for (var i = 0; i < searchResultsCount; i++)
+			{
+				searchResults.Add(SearchResult(i));
+			}
+			return new FakeSearchResults(searchResults);
+		}
+
+		private SearchResult SearchResult(int id)
+		{
+			return new SearchResult
+			{
+				Id = id
+			};
+		}
+
+		private IUnpagedBlogService<BlogModel> Service(IBlogSearch blogSearch, IBlogPostMapper<BlogModel> blogPostMapper)
+			=> new UnpagedBlogService<BlogModel>(blogSearch, blogPostMapper);
+
+		[TestCase(1, 5)]
+		[TestCase(2, 7)]
+		[TestCase(1, 10)]
+		[TestCase(4, 8)]
+		[TestCase(2, 3)]
+		public void GetPosts_Returns_Expected_Range_Of_BlogPosts_And_Expected_Total(int startPost, int endPost)
+		{
+			var totalBlogPostsCount = 10;
+			var expectedResultsCcount = endPost - startPost + 1;
+			var searchResults = SearchResults(totalBlogPostsCount);
+			
+			var blogSearch = BlogSearch(searchResults);
+
+			var service = Service(blogSearch, BlogPostMapper(expectedResultsCcount));
+
+			var results = service.GetPosts(startPost, endPost);
+
+			Assert.That(results.BlogPosts.Count(), Is.EqualTo(expectedResultsCcount));
+			Assert.That(results.TotalItemsCount, Is.EqualTo(totalBlogPostsCount));
+		}
+	}
+}

--- a/Gibe.Umbraco.Blog/BlogPostMapper.cs
+++ b/Gibe.Umbraco.Blog/BlogPostMapper.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Examine;
+using Gibe.DittoServices.ModelConverters;
+using Gibe.Umbraco.Blog.Models;
+using Gibe.UmbracoWrappers;
+using Umbraco.Core.Models;
+
+namespace Gibe.Umbraco.Blog
+{
+	public class BlogPostMapper<T> : IBlogPostMapper<T> where T : class, IBlogPostModel
+	{
+		private readonly IModelConverter _modelConverter;
+		private readonly IUmbracoWrapper _umbracoWrapper;
+
+		public BlogPostMapper(IModelConverter modelConverter, IUmbracoWrapper umbracoWrapper)
+		{
+			_modelConverter = modelConverter;
+			_umbracoWrapper = umbracoWrapper;
+		}
+
+		public IEnumerable<T> ToBlogPosts(IEnumerable<SearchResult> searchResults)
+			=> ToBlogPosts(searchResults.Select(r => _umbracoWrapper.TypedContent(r.Id)));
+
+		public T ToBlogPost(SearchResult searchResult) =>
+			ToBlogPost(_umbracoWrapper.TypedContent(searchResult.Id));
+		
+		private T ToBlogPost(IPublishedContent content)
+			=> _modelConverter.ToModel<T>(content);
+		
+		private IEnumerable<T> ToBlogPosts(IEnumerable<IPublishedContent> content)
+			=> content.Select(ToBlogPost);
+	}
+}

--- a/Gibe.Umbraco.Blog/BlogSearch.cs
+++ b/Gibe.Umbraco.Blog/BlogSearch.cs
@@ -32,7 +32,6 @@ namespace Gibe.Umbraco.Blog
 		
 		private ISearchCriteria GetSearchQuery(IEnumerable<IBlogPostFilter> filters, ISort sort)
 		{
-			
 			return sort.GetCriteria(GetQuery(filters)).Compile();
 		}
 

--- a/Gibe.Umbraco.Blog/BlogService.cs
+++ b/Gibe.Umbraco.Blog/BlogService.cs
@@ -1,31 +1,27 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using Examine;
-using Gibe.DittoServices.ModelConverters;
 using Gibe.Pager.Interfaces;
 using Gibe.Pager.Models;
 using Gibe.Umbraco.Blog.Filters;
 using Gibe.Umbraco.Blog.Models;
 using Gibe.Umbraco.Blog.Sort;
-using Gibe.UmbracoWrappers;
-using Umbraco.Core.Models;
 
 namespace Gibe.Umbraco.Blog
 {
 	public class BlogService<T> : IBlogService<T> where T : class, IBlogPostModel
 	{
-		private readonly IModelConverter _modelConverter;
 		private readonly IPagerService _pagerService;
-		private readonly IUmbracoWrapper _umbracoWrapper;
 		private readonly IBlogSearch _blogSearch;
+		private readonly IBlogPostMapper<T> _blogPostMapper;
 
-		public BlogService(IModelConverter modelConverter, IPagerService pagerService, IBlogSearch blogSearch, IUmbracoWrapper umbracoWrapper)
+		public BlogService(
+			IPagerService pagerService, 
+			IBlogSearch blogSearch, 
+			IBlogPostMapper<T> blogPostMapper)
 		{
-			_modelConverter = modelConverter;
 			_pagerService = pagerService;
 			_blogSearch = blogSearch;
-			_umbracoWrapper = umbracoWrapper;
+			_blogPostMapper = blogPostMapper;
 		}
 
 		public PageQueryResultModel<T> GetPosts(int itemsPerPage, int currentPage)
@@ -47,7 +43,7 @@ namespace Gibe.Umbraco.Blog
 		{
 			var results = _blogSearch.Search(filters, sort);
 			var posts = results.Skip((currentPage - 1) * itemsPerPage).Take(itemsPerPage);
-			return PageQueryResultModel(itemsPerPage, currentPage, ToBlogPosts(posts), results.TotalItemCount);
+			return PageQueryResultModel(itemsPerPage, currentPage, _blogPostMapper.ToBlogPosts(posts), results.TotalItemCount);
 		}
 
 		private PageQueryResultModel<T> PageQueryResultModel(int itemsPerPage, int currentPage, IEnumerable<T> posts, int totalPostCount)
@@ -55,33 +51,18 @@ namespace Gibe.Umbraco.Blog
 			return _pagerService.GetPageQueryResultModel(posts, itemsPerPage, currentPage, totalPostCount);
 		}
 
-		private T ToBlogPost(IPublishedContent content)
-		{
-			return _modelConverter.ToModel<T>(content);
-		}
-
-		private IEnumerable<T> ToBlogPosts(IEnumerable<IPublishedContent> content)
-		{
-			return content.Select(ToBlogPost);
-		}
-
-		private IEnumerable<T> ToBlogPosts(IEnumerable<SearchResult> searchResults)
-		{
-			return ToBlogPosts(searchResults.Select(r => _umbracoWrapper.TypedContent(r.Id)));
-		}
-
 		public T GetNextPost(T current, IEnumerable<IBlogPostFilter> filters, ISort sort)
 		{
 			var results = _blogSearch.Search(filters, sort);
 			var post = results.TakeWhile(r => r.Id != current.Id).LastOrDefault();
-			return post != null ? ToBlogPost(_umbracoWrapper.TypedContent(post.Id)) : null;
+			return post != null ? _blogPostMapper.ToBlogPost(post) : null;
 		}
 
 		public T GetPreviousPost(T current, IEnumerable<IBlogPostFilter> filters, ISort sort)
 		{
 			var results = _blogSearch.Search(filters, sort);
 			var post = results.SkipWhile(r => r.Id != current.Id).Skip(1).FirstOrDefault();
-			return post != null ? ToBlogPost(_umbracoWrapper.TypedContent(post.Id)) : null;
+			return post != null ? _blogPostMapper.ToBlogPost(post) : null;
 		}
 
 		public IEnumerable<T> GetRelatedPosts(T post, int count)
@@ -93,7 +74,7 @@ namespace Gibe.Umbraco.Blog
 		{
 			var filter = new AtLeastOneMatchingTagFilter(tags);
 			var results = _blogSearch.Search(filter, new RelevanceSort()).Where(r => r.Id != postId);
-			return ToBlogPosts(results.Take(count));
+			return _blogPostMapper.ToBlogPosts(results.Take(count));
 		}
 	}
 }

--- a/Gibe.Umbraco.Blog/Gibe.Umbraco.Blog.csproj
+++ b/Gibe.Umbraco.Blog/Gibe.Umbraco.Blog.csproj
@@ -321,6 +321,7 @@
   <ItemGroup>
     <Compile Include="BlogArchive.cs" />
     <Compile Include="BlogAuthors.cs" />
+    <Compile Include="BlogPostMapper.cs" />
     <Compile Include="BlogSearch.cs" />
     <Compile Include="BlogSections.cs" />
     <Compile Include="BlogService.cs" />
@@ -332,10 +333,12 @@
     <Compile Include="Filters\AtLeastOneMatchingTagFilter.cs" />
     <Compile Include="IBlogArchive.cs" />
     <Compile Include="IBlogAuthors.cs" />
+    <Compile Include="IBlogPostMapper.cs" />
     <Compile Include="IBlogSearch.cs" />
     <Compile Include="IBlogSections.cs" />
     <Compile Include="IBlogService.cs" />
     <Compile Include="IBlogTags.cs" />
+    <Compile Include="IUnpagedBlogService.cs" />
     <Compile Include="Models\BlogArchiveModel.cs" />
     <Compile Include="Models\BlogArchiveMonth.cs" />
     <Compile Include="Models\BlogArchiveYear.cs" />
@@ -355,6 +358,7 @@
     <Compile Include="Sort\ISort.cs" />
     <Compile Include="Sort\RelevanceSort.cs" />
     <Compile Include="UmbracoEvents.cs" />
+    <Compile Include="UnpagedBlogService.cs" />
     <Compile Include="Utilities\ExactPhraseExamineValue.cs" />
     <Compile Include="Utilities\Import.cs" />
     <Compile Include="Wrappers\ISearchIndex.cs" />

--- a/Gibe.Umbraco.Blog/IBlogPostMapper.cs
+++ b/Gibe.Umbraco.Blog/IBlogPostMapper.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Examine;
+using Gibe.DittoServices.ModelConverters;
+using Gibe.Umbraco.Blog.Models;
+using Gibe.UmbracoWrappers;
+using Umbraco.Core.Models;
+
+namespace Gibe.Umbraco.Blog
+{
+	public interface IBlogPostMapper<T> where T : IBlogPostModel
+	{
+		IEnumerable<T> ToBlogPosts(IEnumerable<SearchResult> searchResults);
+		T ToBlogPost(SearchResult searchResult);
+	}
+}

--- a/Gibe.Umbraco.Blog/IUnpagedBlogService.cs
+++ b/Gibe.Umbraco.Blog/IUnpagedBlogService.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Gibe.Umbraco.Blog.Filters;
+using Gibe.Umbraco.Blog.Models;
+using Gibe.Umbraco.Blog.Sort;
+
+namespace Gibe.Umbraco.Blog
+{
+	public interface IUnpagedBlogService<T> where T : IBlogPostModel
+	{
+		UnpageBlogSearchResults GetPosts(int startPost, int endPost, ISort sort = null, IEnumerable<IBlogPostFilter> filters = null);
+	}
+}

--- a/Gibe.Umbraco.Blog/IUnpagedBlogService.cs
+++ b/Gibe.Umbraco.Blog/IUnpagedBlogService.cs
@@ -5,8 +5,8 @@ using Gibe.Umbraco.Blog.Sort;
 
 namespace Gibe.Umbraco.Blog
 {
-	public interface IUnpagedBlogService<T> where T : IBlogPostModel
+	public interface IUnpagedBlogService<T> where T : class, IBlogPostModel
 	{
-		UnpageBlogSearchResults GetPosts(int startPost, int endPost, ISort sort = null, IEnumerable<IBlogPostFilter> filters = null);
+		UnpagedBlogSearchResults<T> GetPosts(int startPost, int endPost, ISort sort = null, IEnumerable<IBlogPostFilter> filters = null);
 	}
 }

--- a/Gibe.Umbraco.Blog/IUnpagedBlogService.cs
+++ b/Gibe.Umbraco.Blog/IUnpagedBlogService.cs
@@ -7,6 +7,6 @@ namespace Gibe.Umbraco.Blog
 {
 	public interface IUnpagedBlogService<T> where T : class, IBlogPostModel
 	{
-		UnpagedBlogSearchResults<T> GetPosts(int startPost, int endPost, ISort sort = null, IEnumerable<IBlogPostFilter> filters = null);
+		UnpagedBlogSearchResults<T> GetPosts(int startPost, int postCount, ISort sort = null, IEnumerable<IBlogPostFilter> filters = null);
 	}
 }

--- a/Gibe.Umbraco.Blog/Ninject/GibeUmbracoBlogModule.cs
+++ b/Gibe.Umbraco.Blog/Ninject/GibeUmbracoBlogModule.cs
@@ -15,6 +15,8 @@ namespace Gibe.Umbraco.Blog.Ninject
 			Bind<IBlogSearch>().To<BlogSearch>();
 			Bind<IBlogSections<TBlogSectionModel>>().To<BlogSections<TBlogSectionModel>>();
 			Bind<IBlogService<TBlogPostModel>>().To<BlogService<TBlogPostModel>>();
+			Bind<IUnpagedBlogService<TBlogPostModel>>().To<UnpagedBlogService<TBlogPostModel>>();
+			Bind<IBlogPostMapper<TBlogPostModel>>().To<BlogPostMapper<TBlogPostModel>>();
 			Bind<IBlogTags>().To<BlogTags>();
 			Bind<ISearchIndex>().To<NewsIndex>();
 		}

--- a/Gibe.Umbraco.Blog/UnpagedBlogService.cs
+++ b/Gibe.Umbraco.Blog/UnpagedBlogService.cs
@@ -17,7 +17,7 @@ namespace Gibe.Umbraco.Blog
 			_blogPostMapper = blogPostMapper;
 		}
 
-		public UnpagedBlogSearchResults<T> GetPosts(int startPost, int endPost, ISort sort = null,
+		public UnpagedBlogSearchResults<T> GetPosts(int startPost, int postCount, ISort sort = null,
 			IEnumerable<IBlogPostFilter> filters = null)
 		{
 			if (sort == null) sort = new DateSort();
@@ -27,7 +27,7 @@ namespace Gibe.Umbraco.Blog
 
 			return new UnpagedBlogSearchResults<T>
 			{
-				BlogPosts = _blogPostMapper.ToBlogPosts(results.Skip(startPost != 0 ? startPost - 1 : 0).Take(endPost)),
+				BlogPosts = _blogPostMapper.ToBlogPosts(results.Skip(startPost != 0 ? startPost - 1 : 0).Take(postCount)),
 				TotalItemsCount = results.Count()
 			};
 		}

--- a/Gibe.Umbraco.Blog/UnpagedBlogService.cs
+++ b/Gibe.Umbraco.Blog/UnpagedBlogService.cs
@@ -17,7 +17,7 @@ namespace Gibe.Umbraco.Blog
 			_blogPostMapper = blogPostMapper;
 		}
 
-		public UnpageBlogSearchResults GetPosts(int startPost, int endPost, ISort sort = null,
+		public UnpagedBlogSearchResults<T> GetPosts(int startPost, int endPost, ISort sort = null,
 			IEnumerable<IBlogPostFilter> filters = null)
 		{
 			if (sort == null) sort = new DateSort();
@@ -25,7 +25,7 @@ namespace Gibe.Umbraco.Blog
 
 			var results = _blogSearch.Search(filters, sort);
 
-			return new UnpageBlogSearchResults
+			return new UnpagedBlogSearchResults<T>
 			{
 				BlogPosts = _blogPostMapper.ToBlogPosts(results.Skip(startPost != 0 ? startPost - 1 : 0).Take(endPost)),
 				TotalItemsCount = results.Count()
@@ -33,9 +33,9 @@ namespace Gibe.Umbraco.Blog
 		}
 	}
 
-	public class UnpageBlogSearchResults
+	public class UnpagedBlogSearchResults<T> where T : class, IBlogPostModel
 	{
-		public IEnumerable<IBlogPostModel> BlogPosts { get; set; }
+		public IEnumerable<T> BlogPosts { get; set; }
 		public int TotalItemsCount { get; set; }
 	}
 }

--- a/Gibe.Umbraco.Blog/UnpagedBlogService.cs
+++ b/Gibe.Umbraco.Blog/UnpagedBlogService.cs
@@ -27,7 +27,7 @@ namespace Gibe.Umbraco.Blog
 
 			return new UnpagedBlogSearchResults<T>
 			{
-				BlogPosts = _blogPostMapper.ToBlogPosts(results.Skip(startPost != 0 ? startPost - 1 : 0).Take(postCount)),
+				BlogPosts = _blogPostMapper.ToBlogPosts(results.Skip(startPost - 1).Take(postCount)),
 				TotalItemsCount = results.Count()
 			};
 		}

--- a/Gibe.Umbraco.Blog/UnpagedBlogService.cs
+++ b/Gibe.Umbraco.Blog/UnpagedBlogService.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Gibe.Umbraco.Blog.Filters;
+using Gibe.Umbraco.Blog.Models;
+using Gibe.Umbraco.Blog.Sort;
+
+namespace Gibe.Umbraco.Blog
+{
+	public class UnpagedBlogService<T> : IUnpagedBlogService<T> where T : class, IBlogPostModel
+	{
+		private readonly IBlogSearch _blogSearch;
+		private readonly IBlogPostMapper<T> _blogPostMapper;
+
+		public UnpagedBlogService(IBlogSearch blogSearch, IBlogPostMapper<T> blogPostMapper)
+		{
+			_blogSearch = blogSearch;
+			_blogPostMapper = blogPostMapper;
+		}
+
+		public UnpageBlogSearchResults GetPosts(int startPost, int endPost, ISort sort = null,
+			IEnumerable<IBlogPostFilter> filters = null)
+		{
+			if (sort == null) sort = new DateSort();
+			if (filters == null) filters = Enumerable.Empty<IBlogPostFilter>();
+
+			var results = _blogSearch.Search(filters, sort);
+
+			return new UnpageBlogSearchResults
+			{
+				BlogPosts = _blogPostMapper.ToBlogPosts(results.Skip(startPost != 0 ? startPost - 1 : 0).Take(endPost)),
+				TotalItemsCount = results.Count()
+			};
+		}
+	}
+
+	public class UnpageBlogSearchResults
+	{
+		public IEnumerable<IBlogPostModel> BlogPosts { get; set; }
+		public int TotalItemsCount { get; set; }
+	}
+}


### PR DESCRIPTION
Add a class to support the BR v2 blog which requires 6 posts to be delivered at a time after a first page containing 14/15 posts.

Also minor refactor of some mapper functions out of existing blog service.

Note that due to the current master version of Gibe.Umbraco.Blog being a post Umbraco v8 version, this wont be going any further than release/4.1.0 (which can be considered the "release" version)