### PR TITLE
Move hardcoded doctypes to a settings class for overriding

### DIFF
--- a/Gibe.Umbraco.Blog/BlogSearch.cs
+++ b/Gibe.Umbraco.Blog/BlogSearch.cs
@@ -3,6 +3,7 @@ using Examine;
 using Examine.LuceneEngine.SearchCriteria;
 using Examine.SearchCriteria;
 using Gibe.Umbraco.Blog.Filters;
+using Gibe.Umbraco.Blog.Settings;
 using Gibe.Umbraco.Blog.Sort;
 using Gibe.Umbraco.Blog.Wrappers;
 using Lucene.Net.Search;
@@ -11,13 +12,13 @@ namespace Gibe.Umbraco.Blog
 {
 	public class BlogSearch : IBlogSearch
 	{
-		private const string BlogPostDoctype = "blogPost";
-
 		private readonly ISearchIndex _newsIndex;
+		private readonly IBlogSettings _blogSettings;
 
-		public BlogSearch(ISearchIndex newsIndex)
+		public BlogSearch(ISearchIndex newsIndex, IBlogSettings blogSettings)
 		{
 			_newsIndex = newsIndex;
+			_blogSettings = blogSettings;
 		}
 		
 		public ISearchResults Search(IBlogPostFilter filter, ISort sort)
@@ -37,7 +38,7 @@ namespace Gibe.Umbraco.Blog
 
 		private IBooleanOperation GetQuery(IEnumerable<IBlogPostFilter> filters)
 		{
-			var query = _newsIndex.CreateSearchCriteria().NodeTypeAlias(BlogPostDoctype);
+			var query = _newsIndex.CreateSearchCriteria().NodeTypeAlias(_blogSettings.BlogPostDoctype);
 			foreach (var filter in filters)
 			{
 				query = filter.GetCriteria(query.And());

--- a/Gibe.Umbraco.Blog/BlogSections.cs
+++ b/Gibe.Umbraco.Blog/BlogSections.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Examine;
 using Gibe.DittoServices.ModelConverters;
 using Gibe.Umbraco.Blog.Models;
+using Gibe.Umbraco.Blog.Settings;
 using Gibe.Umbraco.Blog.Wrappers;
 using Gibe.UmbracoWrappers;
 
@@ -10,16 +11,17 @@ namespace Gibe.Umbraco.Blog
 {
 	public class BlogSections<T> : IBlogSections<T> where T : class,IBlogPostSection
 	{
-		private const string BlogSectionDocType = "blogSection";
+		private readonly IBlogSettings _blogSettings;
 		private readonly IUmbracoWrapper _umbracoWrapper;
 		private readonly IModelConverter _modelConverter;
 		private readonly ISearchIndex _searchIndex;
 
-		public BlogSections(IUmbracoWrapper umbracoWrapper, IModelConverter modelConverter, ISearchIndex searchIndex)
+		public BlogSections(IUmbracoWrapper umbracoWrapper, IModelConverter modelConverter, ISearchIndex searchIndex, IBlogSettings blogSettings)
 		{
 			_umbracoWrapper = umbracoWrapper;
 			_modelConverter = modelConverter;
 			_searchIndex = searchIndex;
+			_blogSettings = blogSettings;
 		}
 
 		public IEnumerable<T> All()
@@ -30,7 +32,7 @@ namespace Gibe.Umbraco.Blog
 		
 		private ISearchResults SearchForBlogSections()
 		{
-			var query = _searchIndex.CreateSearchCriteria().NodeTypeAlias(BlogSectionDocType).Compile();
+			var query = _searchIndex.CreateSearchCriteria().NodeTypeAlias(_blogSettings.BlogSectionDoctype).Compile();
 			
 			return _searchIndex.Search(query);
 		}

--- a/Gibe.Umbraco.Blog/Gibe.Umbraco.Blog.csproj
+++ b/Gibe.Umbraco.Blog/Gibe.Umbraco.Blog.csproj
@@ -350,6 +350,7 @@
     <Compile Include="Filters\StandardBlogPostFilter.cs" />
     <Compile Include="Filters\SectionBlogPostFilter.cs" />
     <Compile Include="Filters\TagBlogPostFilter.cs" />
+    <Compile Include="Settings\IBlogSettings.cs" />
     <Compile Include="Sort\DateSort.cs" />
     <Compile Include="Sort\ISort.cs" />
     <Compile Include="Sort\RelevanceSort.cs" />

--- a/Gibe.Umbraco.Blog/Ninject/GibeUmbracoBlogModule.cs
+++ b/Gibe.Umbraco.Blog/Ninject/GibeUmbracoBlogModule.cs
@@ -1,4 +1,5 @@
 ﻿using Gibe.Umbraco.Blog.Models;
+using Gibe.Umbraco.Blog.Settings;
 using Gibe.Umbraco.Blog.Wrappers;
 using Ninject.Modules;
 
@@ -18,6 +19,7 @@ namespace Gibe.Umbraco.Blog.Ninject
 			Bind<IBlogPostMapper<TBlogPostModel>>().To<BlogPostMapper<TBlogPostModel>>();
 			Bind<IBlogTags>().To<BlogTags>();
 			Bind<ISearchIndex>().To<NewsIndex>();
+			Bind<IBlogSettings>().To<DefaultBlogSettings>();
 		}
 	}
 }

--- a/Gibe.Umbraco.Blog/Settings/IBlogSettings.cs
+++ b/Gibe.Umbraco.Blog/Settings/IBlogSettings.cs
@@ -1,0 +1,16 @@
+﻿namespace Gibe.Umbraco.Blog.Settings
+{
+	public interface IBlogSettings
+	{
+		string BlogRootDoctype { get; }
+		string BlogPostDoctype { get; }
+		string BlogSectionDoctype { get;}
+	}
+
+	public class DefaultBlogSettings : IBlogSettings
+	{
+		public string BlogRootDoctype => "blog";
+		public string BlogPostDoctype => "blogPost";
+		public string BlogSectionDoctype => "blogSection";
+	}
+}

--- a/Gibe.Umbraco.Blog/UmbracoEvents.cs
+++ b/Gibe.Umbraco.Blog/UmbracoEvents.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using Examine.LuceneEngine;
+using Gibe.Umbraco.Blog.Settings;
 using Gibe.Umbraco.Blog.Wrappers;
 using Lucene.Net.Documents;
 using Umbraco.Core;
@@ -13,6 +14,13 @@ namespace Gibe.Umbraco.Blog
 {
 	public class UmbracoEvents : IApplicationEventHandler
 	{
+		private readonly IBlogSettings _blogSettings;
+
+		public UmbracoEvents(IBlogSettings blogSettings)
+		{
+			_blogSettings = blogSettings;
+		}
+
 		public void OnApplicationInitialized(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
 		{
 		}
@@ -39,7 +47,7 @@ namespace Gibe.Umbraco.Blog
 		private void IndexerOnDocumentWriting(object sender, DocumentWritingEventArgs documentWritingEventArgs)
 		{
 			var document = documentWritingEventArgs.Document;
-			if (document.Get("nodeTypeAlias") == "blogPost")
+			if (document.Get("nodeTypeAlias") == _blogSettings.BlogPostDoctype)
 			{
 				var postDate = DateTime.ParseExact(document.Get("postDate").Substring(0, 8), "yyyyMMdd", CultureInfo.InvariantCulture);
 				document.Add(new Field("postDateYear", postDate.Year.ToString("0000"), Field.Store.YES, Field.Index.NOT_ANALYZED));
@@ -75,7 +83,7 @@ namespace Gibe.Umbraco.Blog
 			{
 				try
 				{
-					if (entity.ContentType.Alias == "BlogPost" && entity.ParentId != -20)
+					if (entity.ContentType.Alias.ToLower() == _blogSettings.BlogPostDoctype.ToLower() && entity.ParentId != -20)
 					{
 						// TODO : Move code to somewhere better
 						var parentContent = sender.GetById(entity.ParentId);


### PR DESCRIPTION
Move blog related doctypes to a settings class so that they can be overriden in BR project with V2 doctypes.